### PR TITLE
split imports and exports by type

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,12 @@ module.types = vec![
 ];
 
 // Import WASI's `fd_write`, to print to the terminal
-let fd_write = wabam::interface::Import {
+let fd_write = wabam::interface::FuncImport {
     module: "wasi_snapshot_preview1".into(),
     name: "fd_write".into(),
-    desc: wabam::interface::ImportDesc::Func {
-        type_idx: 1, // types[1], see above
-    }
+    type_idx: 1, // types[1], see above
 };
-module.imports.push(fd_write);
+module.imports.functions.push(fd_write);
 
 // Define memory
 let memory = wabam::Limit {
@@ -48,7 +46,7 @@ let body = wabam::instrs!(
     (i32.const 0) // Where the `(ptr, len)` pair is
     (i32.const { text_ptr })
     (i32.store) // Write ptr
-
+    
     (i32.const 0) // Where the `(ptr, len)` pair is
     (i32.const { text.len() as i32 })
     (i32.store offset=4) // Write len
@@ -72,20 +70,16 @@ module.functions.push(func);
 // Export the start function
 let func_export = wabam::interface::Export {
     name: "_start".into(),
-    desc: wabam::interface::ExportDesc::Func {
-        func_idx: 1, // this is where that's important
-    }
+    idx: 1, // this is where that's important
 };
 
 // Export memory
 let mem_export = wabam::interface::Export {
     name: "memory".into(),
-    desc: wabam::interface::ExportDesc::Memory {
-        mem_idx: 0,
-    }
+    idx: 0,
 };
-module.exports.push(func_export);
-module.exports.push(mem_export);
+module.exports.functions.push(func_export);
+module.exports.memories.push(mem_export);
 
 let output = module.build();
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,4 +1,4 @@
-//! [`Import`]s and [`Export`]s are how modules interface with the outside world.
+//! [`Imports`] and [`Exports`] are how modules interface with the outside world.
 
 use crate::{
     encode::{WasmDecode, WasmEncode},
@@ -6,192 +6,326 @@ use crate::{
     GlobalType, Limit,
 };
 
-/// A function, table, memory, or global requested from the host environment.
+/// All functions, tables, memories, and globals requested from the host environment.
 ///
 /// They are required to be supplied for instantiation to succeed.
-#[derive(PartialEq, Eq, Debug, Clone)]
-pub struct Import {
-    pub module: String,
-    pub name: String,
-    pub desc: ImportDesc,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Imports {
+    pub functions: Vec<FuncImport>,
+    pub tables: Vec<TableImport>,
+    pub memories: Vec<MemoryImport>,
+    pub globals: Vec<GlobalImport>,
 }
 
-impl WasmEncode for Import {
+impl Imports {
+    /// The smallest set of imports: nothing.
+    pub const fn empty() -> Self {
+        Self {
+            functions: Vec::new(),
+            tables: Vec::new(),
+            memories: Vec::new(),
+            globals: Vec::new(),
+        }
+    }
+
+    /// The total number of imports
+    pub fn len(&self) -> usize {
+        self.functions.len() + self.tables.len() + self.memories.len() + self.globals.len()
+    }
+
+    /// Are there no imports?
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl Default for Imports {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl WasmEncode for Imports {
     fn size(&self) -> usize {
-        self.module.size() + self.name.size() + self.desc.size()
+        (self.len() as u32).size()
+            + self.functions.iter().map(|x| x.size() + 1).sum::<usize>()
+            + self.tables.iter().map(|x| x.size() + 1).sum::<usize>()
+            + self.memories.iter().map(|x| x.size() + 1).sum::<usize>()
+            + self.globals.iter().map(|x| x.size() + 1).sum::<usize>()
+    }
+
+    fn encode(&self, v: &mut Vec<u8>) {
+        (self.len() as u32).encode(v);
+        // Can't write the len of each vec, so write the elements directly.
+        for func in &self.functions {
+            func.encode(v);
+        }
+        for table in &self.tables {
+            table.encode(v);
+        }
+        for memory in &self.memories {
+            memory.encode(v);
+        }
+        for global in &self.globals {
+            global.encode(v);
+        }
+    }
+}
+
+impl WasmDecode for Imports {
+    fn decode(buf: &mut crate::encode::Buf<'_>) -> Result<Self, crate::ErrorKind> {
+        let len = u32::decode(buf)? as usize;
+        let mut functions = Vec::with_capacity(len);
+        let mut tables = Vec::with_capacity(len);
+        let mut memories = Vec::with_capacity(len);
+        let mut globals = Vec::with_capacity(len);
+
+        for _ in 0..len {
+            let module = String::decode(buf)?;
+            let name = String::decode(buf)?;
+            let discriminant = u8::decode(buf)?;
+            match discriminant {
+                0 => {
+                    let type_idx = u32::decode(buf)?;
+                    functions.push(FuncImport {
+                        module,
+                        name,
+                        type_idx,
+                    });
+                }
+                1 => {
+                    let table_type = TableType::decode(buf)?;
+                    tables.push(TableImport {
+                        module,
+                        name,
+                        table_type,
+                    });
+                }
+                2 => {
+                    let mem_type = Limit::decode(buf)?;
+                    memories.push(MemoryImport {
+                        module,
+                        name,
+                        mem_type,
+                    });
+                }
+                3 => {
+                    let global_type = GlobalType::decode(buf)?;
+                    globals.push(GlobalImport {
+                        module,
+                        name,
+                        global_type,
+                    });
+                }
+                _ => return Err(crate::ErrorKind::InvalidDiscriminant(discriminant)),
+            }
+        }
+        Ok(Self {
+            functions,
+            tables,
+            memories,
+            globals,
+        })
+    }
+}
+
+/// A function import, given by its type index.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FuncImport {
+    pub module: String,
+    pub name: String,
+    pub type_idx: u32,
+}
+
+impl WasmEncode for FuncImport {
+    fn size(&self) -> usize {
+        self.module.size() + self.name.size() + self.type_idx.size()
     }
 
     fn encode(&self, v: &mut Vec<u8>) {
         self.module.encode(v);
         self.name.encode(v);
-        self.desc.encode(v);
+        v.push(0);
+        self.type_idx.encode(v);
     }
 }
 
-impl WasmDecode for Import {
-    fn decode(buf: &mut crate::encode::Buf<'_>) -> Result<Self, crate::encode::ErrorKind> {
-        let module = String::decode(buf)?;
-        let name = String::decode(buf)?;
-        let desc = ImportDesc::decode(buf)?;
-        Ok(Self { module, name, desc })
-    }
+/// A table import, given by its size and type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableImport {
+    pub module: String,
+    pub name: String,
+    pub table_type: TableType,
 }
 
-/// The signature of an import
-///
-/// - A function's type signature index.
-/// - A table's type.
-/// - A memory's size.
-/// - A global's type.
-#[derive(PartialEq, Eq, Debug, Clone)]
-pub enum ImportDesc {
-    Func { type_idx: u32 },
-    Table { table_type: TableType },
-    Memory { mem_type: Limit },
-    Global { global_type: GlobalType },
-}
-
-impl WasmEncode for ImportDesc {
+impl WasmEncode for TableImport {
     fn size(&self) -> usize {
-        use ImportDesc::*;
-        1 + match self {
-            Func { type_idx } => type_idx.size(),
-            Table { table_type } => table_type.size(),
-            Memory { mem_type } => mem_type.size(),
-            Global { global_type } => global_type.size(),
-        }
+        self.module.size() + self.name.size() + self.table_type.size()
     }
 
     fn encode(&self, v: &mut Vec<u8>) {
-        use ImportDesc::*;
-        match self {
-            Func { type_idx } => {
-                v.push(0);
-                type_idx.encode(v);
-            }
-            Table { table_type } => {
-                v.push(1);
-                table_type.encode(v);
-            }
-            Memory { mem_type } => {
-                v.push(2);
-                mem_type.encode(v);
-            }
-            Global { global_type } => {
-                v.push(3);
-                global_type.encode(v);
-            }
+        self.module.encode(v);
+        self.name.encode(v);
+        v.push(1);
+        self.table_type.encode(v);
+    }
+}
+
+/// A function import, given by its size.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryImport {
+    pub module: String,
+    pub name: String,
+    pub mem_type: Limit,
+}
+
+impl WasmEncode for MemoryImport {
+    fn size(&self) -> usize {
+        self.module.size() + self.name.size() + self.mem_type.size()
+    }
+
+    fn encode(&self, v: &mut Vec<u8>) {
+        self.module.encode(v);
+        self.name.encode(v);
+        v.push(2);
+        self.mem_type.encode(v);
+    }
+}
+
+/// A function import, given by its mutability and type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GlobalImport {
+    pub module: String,
+    pub name: String,
+    pub global_type: GlobalType,
+}
+
+impl WasmEncode for GlobalImport {
+    fn size(&self) -> usize {
+        self.module.size() + self.name.size() + self.global_type.size()
+    }
+
+    fn encode(&self, v: &mut Vec<u8>) {
+        self.module.encode(v);
+        self.name.encode(v);
+        v.push(3);
+        self.global_type.encode(v);
+    }
+}
+
+/// The set of all exports provided by the module.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Exports {
+    pub functions: Vec<Export>,
+    pub tables: Vec<Export>,
+    pub memories: Vec<Export>,
+    pub globals: Vec<Export>,
+}
+
+impl Exports {
+    /// The smallest set of exports: nothing.
+    pub const fn empty() -> Self {
+        Self {
+            functions: Vec::new(),
+            tables: Vec::new(),
+            memories: Vec::new(),
+            globals: Vec::new(),
+        }
+    }
+
+    /// The total number of exports
+    pub fn len(&self) -> usize {
+        self.functions.len() + self.tables.len() + self.memories.len() + self.globals.len()
+    }
+
+    /// Are there no exports?
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl Default for Exports {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl WasmEncode for Exports {
+    fn size(&self) -> usize {
+        (self.len() as u32).size()
+            + self
+                .functions
+                .iter()
+                .map(|x| x.name.size() + 1 + x.idx.size())
+                .sum::<usize>()
+            + self
+                .tables
+                .iter()
+                .map(|x| x.name.size() + 1 + x.idx.size())
+                .sum::<usize>()
+            + self
+                .memories
+                .iter()
+                .map(|x| x.name.size() + 1 + x.idx.size())
+                .sum::<usize>()
+            + self
+                .globals
+                .iter()
+                .map(|x| x.name.size() + 1 + x.idx.size())
+                .sum::<usize>()
+    }
+
+    fn encode(&self, v: &mut Vec<u8>) {
+        (self.len() as u32).encode(v);
+        // Can't write the len of each vec, so write the elements directly.
+        for func in &self.functions {
+            (&func.name, 0u8, &func.idx).encode(v);
+        }
+        for table in &self.tables {
+            (&table.name, 1u8, &table.idx).encode(v);
+        }
+        for memory in &self.memories {
+            (&memory.name, 2u8, &memory.idx).encode(v);
+        }
+        for global in &self.globals {
+            (&global.name, 3u8, &global.idx).encode(v);
         }
     }
 }
 
-impl WasmDecode for ImportDesc {
-    fn decode(buf: &mut crate::encode::Buf<'_>) -> Result<Self, crate::encode::ErrorKind> {
-        let d = u8::decode(buf)?;
-        match d {
-            0 => Ok(Self::Func {
-                type_idx: u32::decode(buf)?,
-            }),
-            1 => Ok(Self::Table {
-                table_type: TableType::decode(buf)?,
-            }),
-            2 => Ok(Self::Memory {
-                mem_type: Limit::decode(buf)?,
-            }),
-            3 => Ok(Self::Global {
-                global_type: GlobalType::decode(buf)?,
-            }),
-            _ => Err(crate::encode::ErrorKind::InvalidDiscriminant(d)),
+impl WasmDecode for Exports {
+    fn decode(buf: &mut crate::encode::Buf<'_>) -> Result<Self, crate::ErrorKind> {
+        let len = u32::decode(buf)? as usize;
+        let mut functions = Vec::with_capacity(len);
+        let mut tables = Vec::with_capacity(len);
+        let mut memories = Vec::with_capacity(len);
+        let mut globals = Vec::with_capacity(len);
+
+        for _ in 0..len {
+            let name = String::decode(buf)?;
+            let discriminant = u8::decode(buf)?;
+            let idx = u32::decode(buf)?;
+            let export = Export { name, idx };
+            match discriminant {
+                0 => functions.push(export),
+                1 => tables.push(export),
+                2 => memories.push(export),
+                3 => globals.push(export),
+                _ => return Err(crate::ErrorKind::InvalidDiscriminant(discriminant)),
+            }
         }
+        Ok(Self {
+            functions,
+            tables,
+            memories,
+            globals,
+        })
     }
 }
 
-/// A module's internal resource that is exported to the host environment.
-///
-/// The name must be unique within the module.
-#[derive(PartialEq, Eq, Debug, Clone)]
+/// The name and index of an exported item.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Export {
     pub name: String,
-    pub desc: ExportDesc,
-}
-
-impl WasmEncode for Export {
-    fn size(&self) -> usize {
-        self.name.size() + self.desc.size()
-    }
-
-    fn encode(&self, v: &mut Vec<u8>) {
-        self.name.encode(v);
-        self.desc.encode(v);
-    }
-}
-
-impl WasmDecode for Export {
-    fn decode(buf: &mut crate::encode::Buf<'_>) -> Result<Self, crate::encode::ErrorKind> {
-        let name = String::decode(buf)?;
-        let desc = ExportDesc::decode(buf)?;
-        Ok(Self { name, desc })
-    }
-}
-
-/// The index of an exported resource
-#[derive(PartialEq, Eq, Debug, Clone)]
-pub enum ExportDesc {
-    Func { func_idx: u32 },
-    Table { table_idx: u32 },
-    Memory { mem_idx: u32 },
-    Global { global_idx: u32 },
-}
-
-impl WasmEncode for ExportDesc {
-    fn size(&self) -> usize {
-        1 + match self {
-            ExportDesc::Func { func_idx } => func_idx.size(),
-            ExportDesc::Table { table_idx } => table_idx.size(),
-            ExportDesc::Memory { mem_idx } => mem_idx.size(),
-            ExportDesc::Global { global_idx } => global_idx.size(),
-        }
-    }
-
-    fn encode(&self, v: &mut Vec<u8>) {
-        match self {
-            ExportDesc::Func { func_idx } => {
-                v.push(0);
-                func_idx.encode(v);
-            }
-            ExportDesc::Table { table_idx } => {
-                v.push(1);
-                table_idx.encode(v);
-            }
-            ExportDesc::Memory { mem_idx } => {
-                v.push(2);
-                mem_idx.encode(v);
-            }
-            ExportDesc::Global { global_idx } => {
-                v.push(3);
-                global_idx.encode(v);
-            }
-        }
-    }
-}
-
-impl WasmDecode for ExportDesc {
-    fn decode(buf: &mut crate::encode::Buf<'_>) -> Result<Self, crate::encode::ErrorKind> {
-        let d = u8::decode(buf)?;
-        match d {
-            0 => Ok(Self::Func {
-                func_idx: u32::decode(buf)?,
-            }),
-            1 => Ok(Self::Table {
-                table_idx: u32::decode(buf)?,
-            }),
-            2 => Ok(Self::Memory {
-                mem_idx: u32::decode(buf)?,
-            }),
-            3 => Ok(Self::Global {
-                global_idx: u32::decode(buf)?,
-            }),
-            _ => Err(crate::encode::ErrorKind::InvalidDiscriminant(d)),
-        }
-    }
+    pub idx: u32,
 }


### PR DESCRIPTION
This makes interacting with them much easier, having them woven together was a pain.