### PR TITLE
add `Module::empty`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,6 +249,9 @@ pub struct Module {
 }
 
 impl Module {
+    /// An entirely empty module.
+    /// 
+    /// Calling `Module::build` on this will just return the 8-byte header.
     pub const EMPTY: Self = Self {
         custom_sections: Vec::new(),
         types: Vec::new(),
@@ -263,6 +266,9 @@ impl Module {
         datas: Vec::new(),
     };
 
+    /// An entirely empty module.
+    /// 
+    /// Calling `Module::build` on this will just return the 8-byte header.
     pub const fn empty() -> Self {
         Self::EMPTY
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,6 +263,10 @@ impl Module {
         datas: Vec::new(),
     };
 
+    pub const fn empty() -> Self {
+        Self::EMPTY
+    }
+
     /// Assembles the module into the wasm binary format.
     pub fn build(&self) -> Vec<u8> {
         let mut v = Vec::with_capacity(self.size());


### PR DESCRIPTION
Because I think functions look nicer than constants